### PR TITLE
Allow sending to IPs and default to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ children = [
 Supervisor.start_link(children, ...)
 ```
 
-By default the reporter sends metrics to localhost:8125 - both hostname and port number can be
+By default the reporter sends metrics to 127.0.0.1:8125 - both hostname / IP and port number can be
 configured using the `:host` and `:port` options. You can also configure the prefix for all the
 published metrics using the `:prefix` option.
 

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -4,12 +4,13 @@ defmodule TelemetryMetricsStatsd.UDP do
   defstruct [:host, :port, :socket]
 
   @opaque t :: %__MODULE__{
-            host: :inet.hostname(),
+            host: :inet.hostname() | :inet.ip_address(),
             port: :inet.port_number(),
             socket: :gen_udp.socket()
           }
 
-  @spec open(:inet.hostname(), :inet.port_number()) :: {:ok, t()} | {:error, reason :: term()}
+  @spec open(:inet.hostname() | :inet.ip_address(), :inet.port_number()) ::
+          {:ok, t()} | {:error, reason :: term()}
   def open(host, port) do
     case :gen_udp.open(0) do
       {:ok, socket} ->


### PR DESCRIPTION
I am using TelemetryMetricsStatsd to send Ecto query telemetry. I
noticed this slowed down some of our calls. One of the more expensive
operations is apparently :inet_udp.getaddr/1. However, there is no need
to look up localhost using this function. I have included some benchmark
information collected with fprof below.

When using localhost:

```
TelemetryMetricsStatsd.UDP.send/2                                   12      12.319       0.088
  :gen_udp.send/4                                                   12      12.319       0.088  <--
    :inet_db.lookup_socket/1                                        12       0.051       0.034
    :inet_udp.send/4                                                12       0.622       0.023
    :inet_udp.getaddr/1                                             12      11.545       0.020
    :inet_udp.getserv/1                                             12       0.013       0.013
```

When using 127.0.0.1:

```
TelemetryMetricsStatsd.UDP.send/2                                   12       2.560       0.095
  :gen_udp.send/4                                                   12       2.560       0.095  <--
    :inet_db.lookup_socket/1                                        12       0.061       0.040
    :inet_udp.send/4                                                12       2.181       0.024
    :inet_udp.getaddr/1                                             12       0.208       0.018
    :inet_udp.getserv/1                                             12       0.015       0.015
```

Load tests of my application also show a significant performance improvement after this change.