### PR TITLE
Support using the sum metric for StatsD and Datadog counters

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -47,7 +47,7 @@ defmodule TelemetryMetricsStatsd do
   |-------------------|--------|
   | `last_value`      | `gauge`, always set to an absolute value |
   | `counter`         | `counter`, always increased by 1 |
-  | `sum`             | `gauge`, increased and decreased by the provided value |
+  | `sum`             | `gauge`, increased and decreased by the provided value, or `counter`, set to the provided value |
   | `summary`         | `timer` recording individual measurement |
   | `histogram`       | Reported as histogram if DataDog formatter is used |
 
@@ -124,6 +124,22 @@ defmodule TelemetryMetricsStatsd do
       "http.request.count:+1076|g"
 
   When the measurement is negative, the StatsD gauge is decreased accordingly.
+
+  When the `report_as: :counter` reporter option is passed, the Sum metric is reported as
+  a counter, and set to the value provided. Negative values are not supported
+  and will be logged and dropped in this case.
+
+  Given the metric definition
+
+      sum("kafka.consume.batch_size", reporter_options: [report_as: :counter])
+
+  and the event
+
+      :telemetry.execute([:kafka, :consume], %{batch_size: 200})
+
+  the following would be sent to StatsD
+
+      "kafka.consume.batch_size:200|c"
 
   #### Summary
 

--- a/lib/telemetry_metrics_statsd/formatter/standard.ex
+++ b/lib/telemetry_metrics_statsd/formatter/standard.ex
@@ -5,15 +5,23 @@ defmodule TelemetryMetricsStatsd.Formatter.Standard do
 
   alias Telemetry.Metrics
 
+  require Logger
+
   @impl true
   def format(metric, value, tags) do
-    [
-      format_metric_name(metric.name),
-      format_metric_tags(tags),
-      ?:,
-      format_metric_value(metric, value),
-      format_sampling_rate(metric.reporter_options)
-    ]
+    case format_metric_value(metric, value) do
+      [] ->
+        []
+
+      val ->
+        [
+          format_metric_name(metric.name),
+          format_metric_tags(tags),
+          ?:,
+          val,
+          format_sampling_rate(metric.reporter_options)
+        ]
+    end
   end
 
   defp format_metric_name([segment]) do
@@ -47,10 +55,28 @@ defmodule TelemetryMetricsStatsd.Formatter.Standard do
   defp format_metric_value(%Metrics.LastValue{}, value),
     do: [value |> round() |> :erlang.integer_to_binary(), "|g"]
 
-  defp format_metric_value(%Metrics.Sum{}, value) when value >= 0,
+  defp format_metric_value(%Metrics.Sum{reporter_options: reporter_options} = sum, value) do
+    case Keyword.get(reporter_options, :report_as) do
+      :counter -> format_counter_metric_value(sum, value)
+      _ -> format_sum_metric_value(sum, value)
+    end
+  end
+
+  defp format_counter_metric_value(%Metrics.Sum{}, value) when value >= 0,
+    do: [value |> round() |> :erlang.integer_to_binary(), "|c"]
+
+  defp format_counter_metric_value(%Metrics.Sum{}, value) do
+    Logger.warn(
+      "Unable to format negative value: #{inspect(value)} for reporting to StatsD Counter"
+    )
+
+    []
+  end
+
+  defp format_sum_metric_value(%Metrics.Sum{}, value) when value >= 0,
     do: [?+, value |> round() |> :erlang.integer_to_binary(), "|g"]
 
-  defp format_metric_value(%Metrics.Sum{}, value),
+  defp format_sum_metric_value(%Metrics.Sum{}, value),
     do: [value |> round() |> :erlang.integer_to_binary(), "|g"]
 
   defp format_sampling_rate(reporter_options) do

--- a/test/telemetry_metrics_statsd/formatter/datadog_test.exs
+++ b/test/telemetry_metrics_statsd/formatter/datadog_test.exs
@@ -23,6 +23,19 @@ defmodule TelemetryMetricsStatsd.Formatter.DatadogTest do
     assert format(m, -21, []) == "my.awesome.metric:-21|g"
   end
 
+  test "positive sum update as counter is formatted as a Datadog counter with n value" do
+    m = %{given_sum("my.awesome.metric") | reporter_options: [report_as: :counter]}
+
+    assert format(m, 21, []) == "my.awesome.metric:21|c"
+  end
+
+  @tag capture_log: true
+  test "negative sum update as counter for Datadog is dropped" do
+    m = %{given_sum("my.awesome.metric") | reporter_options: [report_as: :counter]}
+
+    assert format(m, -21, []) == ""
+  end
+
   test "last_value update is formatted as a Datadog gauge with absolute value" do
     m = given_last_value("my.awesome.metric")
 

--- a/test/telemetry_metrics_statsd/formatter/standard_test.exs
+++ b/test/telemetry_metrics_statsd/formatter/standard_test.exs
@@ -23,6 +23,19 @@ defmodule TelemetryMetricsStatsd.Formatter.StandardTest do
     assert format(m, -21, []) == "my.awesome.metric:-21|g"
   end
 
+  test "positive sum as counter update is formatted as a StatsD counter with n value" do
+    m = %{given_sum("my.awesome.metric") | reporter_options: [report_as: :counter]}
+
+    assert format(m, 21, []) == "my.awesome.metric:21|c"
+  end
+
+  @tag capture_log: true
+  test "negative sum as counter update is dropped" do
+    m = %{given_sum("my.awesome.metric") | reporter_options: [report_as: :counter]}
+
+    assert format(m, -21, []) == ""
+  end
+
   test "last_value update is formatted as a StatsD gauge with absolute value" do
     m = given_last_value("my.awesome.metric")
 


### PR DESCRIPTION
The counter metric only supports incrementing by 1, but often there is need to increment a counter by the metric value. This adds that support to the standard and Datadog sum metric with a custom `report_as` option as discussed in #27 and based on the work in #25. 

In the case of a negative value, the metric will be dropped, and logged, as negative counters are not supported. (@arkgil please check that part, I've set it up to format the metric as `""` in this case, but if there is a better way to drop the metric then I'm happy to modify).

Docs and tests have been updated as well

Fixes #27