### PR TITLE
Support Unix Domain Sockets

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -21,6 +21,22 @@ defmodule TelemetryMetricsStatsd do
   By default the reporter sends metrics to 127.0.0.1:8125 - both hostname and port number can be
   configured using the `:host` and `:port` options.
 
+      TelemetryMetricsStatsd.start_link(
+        metrics: metrics,
+        host: "statsd",
+        port: 1234
+      )
+
+  Alternatively, a Unix domain socket path can be provided using the `:socket_path` option.
+
+      TelemetryMetricsStatsd.start_link(
+        metrics: metrics,
+        socket_path: "/var/run/statsd.sock"
+      )
+
+  If the `:socket_path` option is provided, `:host` and `:port` parameters are ignored and the
+  connection is established exclusively via Unix domain socket.
+
   Note that the reporter doesn't aggregate metrics in-process - it sends metric updates to StatsD
   whenever a relevant Telemetry event is emitted.
 

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -1,20 +1,38 @@
 defmodule TelemetryMetricsStatsd.UDP do
   @moduledoc false
 
-  defstruct [:host, :port, :socket]
+  defstruct [:host, :port, :socket, :socket_path]
 
   @opaque t :: %__MODULE__{
             host: :inet.hostname() | :inet.ip_address(),
             port: :inet.port_number(),
-            socket: :gen_udp.socket()
+            socket: :gen_udp.socket(),
+            socket_path: binary()
           }
 
-  @spec open(:inet.hostname() | :inet.ip_address(), :inet.port_number()) ::
+  @type ip_config :: %{
+          host: :inet.hostname() | :inet.ip_address(),
+          port: :inet.port_number()
+        }
+  @type local_config :: %{
+          socket_path: binary()
+        }
+  @type config :: ip_config() | local_config()
+
+  @spec open(config()) ::
           {:ok, t()} | {:error, reason :: term()}
-  def open(host, port) do
-    case :gen_udp.open(0) do
+  def open(config) do
+    opts = if config[:socket_path], do: [:local], else: []
+
+    case :gen_udp.open(0, opts) do
       {:ok, socket} ->
-        {:ok, %__MODULE__{host: host, port: port, socket: socket}}
+        {:ok,
+         %__MODULE__{
+           host: config[:host],
+           port: config[:port],
+           socket: socket,
+           socket_path: config[:socket_path]
+         }}
 
       {:error, _} = err ->
         err
@@ -22,7 +40,11 @@ defmodule TelemetryMetricsStatsd.UDP do
   end
 
   @spec send(t(), iodata()) :: :ok | {:error, reason :: term()}
-  def send(%__MODULE__{host: host, port: port, socket: socket}, data) do
-    :gen_udp.send(socket, host, port, data)
+  def send(%__MODULE__{host: host, port: port, socket: socket, socket_path: socket_path}, data) do
+    if socket_path do
+      :gen_udp.send(socket, {:local, socket_path}, 0, data)
+    else
+      :gen_udp.send(socket, host, port, data)
+    end
   end
 end

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -332,7 +332,7 @@ defmodule TelemetryMetricsStatsdTest do
 
       :telemetry.execute([:http, :request], %{latency: 213})
 
-      assert_reported(socket, "http.requests:1|c")
+      assert_reported(socket, "http.request.count:1|c")
     end
   end
 
@@ -518,7 +518,7 @@ defmodule TelemetryMetricsStatsdTest do
   defp given_unix_socket_opened() do
     socket_name = :crypto.strong_rand_bytes(50) |> Base.encode16(case: :lower)
     socket_path = Path.join("/tmp", socket_name)
-    {:ok, socket} = :gen_udp.open(0, [:binary, active: false, ifaddr: {:local, socket_path}])
+    {:ok, socket} = :gen_udp.open(0, [:binary, :local, active: false, ip: {:local, socket_path}])
     {socket, socket_path}
   end
 


### PR DESCRIPTION
Adds Unix domain socket support by extending the reporter configuration options with `socket_path` and changing how the connection is opened and data is sent based on its presence.

This is a draft - let me know if the initial idea looks good and I will continue with updating the docs. In the meantime, I'll do some testing with the DogStatsD agent.

Fixes #17.