### PR TITLE
Close old socket after opening a new one

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -441,8 +441,9 @@ defmodule TelemetryMetricsStatsd do
     Logger.error("Failed to publish metrics over UDP: #{inspect(reason)}")
 
     case UDP.open(state.udp_config) do
-      {:ok, udp} ->
-        {:noreply, %{state | udp: udp}}
+      {:ok, new_udp} ->
+        UDP.close(udp)
+        {:noreply, %{state | udp: new_udp}}
 
       {:error, reason} ->
         Logger.error("Failed to reopen UDP socket: #{inspect(reason)}")

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -47,4 +47,9 @@ defmodule TelemetryMetricsStatsd.UDP do
       :gen_udp.send(socket, host, port, data)
     end
   end
+
+  @spec close(t()) :: :ok
+  def close(%__MODULE__{socket: socket}) do
+    :gen_udp.close(socket)
+  end
 end

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -284,7 +284,7 @@ defmodule TelemetryMetricsStatsdTest do
   end
 
   describe "UDP error handling" do
-    test "notifying a UDP error logs an error" do
+    test "reporting a UDP error logs an error" do
       reporter = start_reporter(metrics: [])
       udp = TelemetryMetricsStatsd.get_udp(reporter)
 
@@ -296,7 +296,7 @@ defmodule TelemetryMetricsStatsdTest do
              end) =~ ~r/\[error\] Failed to publish metrics over UDP: :closed/
     end
 
-    test "notifying a UDP error for the same socket multiple times generates only one log" do
+    test "reporting a UDP error for the same socket multiple times generates only one log" do
       reporter = start_reporter(metrics: [])
       udp = TelemetryMetricsStatsd.get_udp(reporter)
 
@@ -312,7 +312,7 @@ defmodule TelemetryMetricsStatsdTest do
     end
 
     @tag :capture_log
-    test "notifying a UDP error and fetching a socket returns a new socket" do
+    test "reporting a UDP error and fetching a socket returns a new socket" do
       reporter = start_reporter(metrics: [])
       udp = TelemetryMetricsStatsd.get_udp(reporter)
 
@@ -320,6 +320,17 @@ defmodule TelemetryMetricsStatsdTest do
       new_udp = TelemetryMetricsStatsd.get_udp(reporter)
 
       assert new_udp != udp
+    end
+
+    @tag :capture_log
+    test "reporting a UDP error and opening a new socket closes the old socket" do
+      reporter = start_reporter(metrics: [])
+      udp = TelemetryMetricsStatsd.get_udp(reporter)
+
+      TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
+      Process.sleep(100)
+
+      assert :gen_udp.recv(udp.socket, 0) == {:error, :closed}
     end
   end
 


### PR DESCRIPTION
This makes sure the old, failing socket gets closed after a new socket gets opened. Fixes #39.