### PR TITLE
Bump the lower Elixir version on CI to 1.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,10 @@ workflows:
           elixir: "1.10.0"
           otp: "21"
       - telemetry_metrics_statsd/build_and_test:
-          name: "1.6-otp-21"
-          elixir: "1.6.6"
-          otp: "21"
+          name: "1.7-otp-22"
+          elixir: "1.7.4"
+          otp: "22"
       - telemetry_metrics_statsd/build_and_test:
-          name: "1.6-otp-19"
-          elixir: "1.6.6"
+          name: "1.7-otp-19"
+          elixir: "1.7.4"
           otp: "19"


### PR DESCRIPTION
1.11 is on the way, and we need to bump the version to satisfy dependency requirement in #41 