### PR TITLE
Statsd host updating + async send

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -322,7 +322,7 @@ defmodule TelemetryMetricsStatsd do
           | {:formatter, :standard | :datadog}
           | {:global_tags, Keyword.t()}
           | {:name, atom()}
-          | {:sync_send, boolean()}
+          | {:async_send, boolean()}
   @type options :: [option]
 
   @default_port 8125
@@ -399,7 +399,7 @@ defmodule TelemetryMetricsStatsd do
       |> Map.update!(:formatter, &validate_and_translate_formatter/1)
       |> Map.put_new(:global_tags, Keyword.new())
       |> Map.put_new(:pool_size, 1)
-      |> Map.put_new(:sync_send, false)
+      |> Map.put_new(:aasync_send, false)
 
     gen_server_opts =
       case Map.get(config, :name) do
@@ -473,7 +473,7 @@ defmodule TelemetryMetricsStatsd do
         config.prefix,
         config.formatter,
         config.global_tags,
-        config.sync_send
+        config.async_send
       )
 
     {:ok, %{udp_config: udp_config, handler_ids: handler_ids, pool_id: pool_id}}

--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -399,7 +399,7 @@ defmodule TelemetryMetricsStatsd do
       |> Map.update!(:formatter, &validate_and_translate_formatter/1)
       |> Map.put_new(:global_tags, Keyword.new())
       |> Map.put_new(:pool_size, 1)
-      |> Map.put_new(:aasync_send, false)
+      |> Map.put_new(:async_send, false)
 
     gen_server_opts =
       case Map.get(config, :name) do

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -12,11 +12,11 @@ defmodule TelemetryMetricsStatsd.EventHandler do
           prefix :: String.t() | nil,
           formatter :: Formatter.t(),
           global_tags :: Keyword.t(),
-          sync_send :: boolean()
+          async_send :: boolean()
         ) :: [
           :telemetry.handler_id()
         ]
-  def attach(metrics, reporter, pool_id, mtu, prefix, formatter, global_tags, sync_send) do
+  def attach(metrics, reporter, pool_id, mtu, prefix, formatter, global_tags, async_send) do
     metrics_by_event = Enum.group_by(metrics, & &1.event_name)
 
     for {event_name, metrics} <- metrics_by_event do
@@ -31,7 +31,7 @@ defmodule TelemetryMetricsStatsd.EventHandler do
           prefix: prefix,
           formatter: formatter,
           global_tags: global_tags,
-          sync_send: sync_send
+          async_send: async_send
         })
 
       handler_id
@@ -55,7 +55,7 @@ defmodule TelemetryMetricsStatsd.EventHandler do
         prefix: prefix,
         formatter: formatter_mod,
         global_tags: global_tags,
-        sync_send: sync_send
+        async_send: async_send
       }) do
     packets =
       for metric <- metrics do
@@ -78,7 +78,7 @@ defmodule TelemetryMetricsStatsd.EventHandler do
       [] ->
         :ok
 
-      packets when sync_send ->
+      packets when async_send ->
         sync_publish_metrics(reporter, Packet.build_packets(packets, mtu, "\n"))
 
       packets ->

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -48,6 +48,11 @@ defmodule TelemetryMetricsStatsd.UDP do
     end
   end
 
+  @spec update(t(), :inet.hostname() | :inet.ip_address(), :inet.port_number()) :: t()
+  def update(%__MODULE__{} = udp, new_host, new_port) do
+    %__MODULE__{udp | host: new_host, port: new_port}
+  end
+
   @spec close(t()) :: :ok
   def close(%__MODULE__{socket: socket}) do
     :gen_udp.close(socket)

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -349,6 +349,56 @@ defmodule TelemetryMetricsStatsdTest do
     end
   end
 
+  test "StatsD host can be reconfigured on the fly" do
+    {socket, port} = given_udp_port_opened()
+    counter = given_counter("http.request.count")
+
+    reporter =
+      start_reporter(
+        host: "localhost",
+        port: port,
+        metrics: [counter],
+        name: :my_statsd
+      )
+
+    pool_id = TelemetryMetricsStatsd.get_pool_id(reporter)
+
+    udp = TelemetryMetricsStatsd.get_udp(pool_id)
+    assert udp.port == port
+    assert udp.host == 'localhost'
+
+    :telemetry.execute([:http, :request], %{latency: 213})
+
+    assert_reported(socket, "http.request.count:1|c")
+
+    {new_socket, new_port} = given_udp_port_opened()
+
+    TelemetryMetricsStatsd.update_host(reporter, {127, 0, 0, 1}, new_port)
+
+    new_udp = TelemetryMetricsStatsd.get_udp(pool_id)
+    assert new_udp.port == new_port
+    assert new_udp.host == {127, 0, 0, 1}
+    :telemetry.execute([:http, :request], %{latency: 213})
+    assert_reported(new_socket, "http.request.count:1|c")
+  end
+
+  test "metrics can be send synchronously" do
+    {socket, port} = given_udp_port_opened()
+    counter = given_counter("http.request.count")
+
+    start_reporter(
+      host: "localhost",
+      port: port,
+      metrics: [counter],
+      name: :my_statsd,
+      sync_send: true
+    )
+
+    :telemetry.execute([:http, :request], %{latency: 213})
+
+    assert_reported(socket, "http.request.count:1|c")
+  end
+
   test "published metrics are prefixed with the provided prefix" do
     {socket, port} = given_udp_port_opened()
 

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -391,7 +391,7 @@ defmodule TelemetryMetricsStatsdTest do
       port: port,
       metrics: [counter],
       name: :my_statsd,
-      sync_send: true
+      async_send: true
     )
 
     :telemetry.execute([:http, :request], %{latency: 213})


### PR DESCRIPTION
Kicking off this PR so we can have some more discussion on this hopefully. :)

This PR adds two things:
1. Ability to change the statsd hostname and/or port on the fly
2. Asynchronous sending of metrics

I'm not super happy with the solution for 2. however I'd like to hear your opinions first whether I should even go that way. What I'd like to do further is to:

- Add a pool of metric-sending worker processes, 
- Dispatch each metric to a random member of that pool, instead of all routing through the single `TelemetryMetricsStatsd` process
- Replace the ETS pool for the `async_send: true` case with the pool as it does not make sense in that context
- Clean up some duplicate code

