### PR TITLE
Allow empty and missing tag values

### DIFF
--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -63,7 +63,7 @@ defmodule TelemetryMetricsStatsd.EventHandler do
             |> Map.new()
             |> Map.merge(metric.tag_values.(metadata))
 
-          tags = Enum.map(metric.tags, &{&1, Map.fetch!(tag_values, &1)})
+          tags = Enum.map(metric.tags, &{&1, Map.get(tag_values, &1, "")})
           Formatter.format(formatter_mod, metric, prefix, value, tags)
         else
           :nopublish

--- a/test/telemetry_metrics_statsd/formatter/datadog_test.exs
+++ b/test/telemetry_metrics_statsd/formatter/datadog_test.exs
@@ -55,6 +55,13 @@ defmodule TelemetryMetricsStatsd.Formatter.DatadogTest do
              "my.awesome.metric:131|g|#method:nil,status:200"
   end
 
+  test "empty tag values are included in the formatted metric" do
+    m = given_last_value("my.awesome.metric", tags: [:method, :status])
+
+    assert format(m, 131, method: "", status: 200) ==
+             "my.awesome.metric:131|g|#method:,status:200"
+  end
+
   test "tags passed as explicit argument are used for the formatted metric" do
     m = given_last_value("my.awesome.metric", tags: [:whatever])
 

--- a/test/telemetry_metrics_statsd/formatter/standard_test.exs
+++ b/test/telemetry_metrics_statsd/formatter/standard_test.exs
@@ -68,6 +68,12 @@ defmodule TelemetryMetricsStatsd.Formatter.StandardTest do
              "my.awesome.metric.nil.200:131|g"
   end
 
+  test "empty string tag values are dropped" do
+    m = given_last_value("my.awesome.metric", tags: [:method, :status])
+
+    assert format(m, 131, method: "", status: 200) == ""
+  end
+
   test "tags passed as explicit argument are used for the formatted metric" do
     m = given_last_value("my.awesome.metric", tags: [:whatever])
 


### PR DESCRIPTION
With standard StatsD formatter, if the tag value is empty or missing,
the metric update is not sent at all, because the formatted metric name
would be malformed.

With DataDog formatter, an empty tag value is sent.

Closes #43 