### PR TITLE
Set active: false on UDP sockets

### DIFF
--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -22,7 +22,8 @@ defmodule TelemetryMetricsStatsd.UDP do
   @spec open(config()) ::
           {:ok, t()} | {:error, reason :: term()}
   def open(config) do
-    opts = if config[:socket_path], do: [:local], else: []
+    opts = [active: false]
+    opts = if config[:socket_path], do: [:local | opts], else: opts
 
     case :gen_udp.open(0, opts) do
       {:ok, socket} ->


### PR DESCRIPTION
There is no consistent difference in performance for active vs
non-active sockets, so for the piece of mind we might make them non-active.