### PR TITLE
Add telemetry to dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
 
   defp deps do
     [
+      {:telemetry, "~> 0.4"},
       {:telemetry_metrics, "~> 0.5"},
       {:nimble_options, "~> 0.3"},
       {:stream_data, "~> 0.4", only: :test},


### PR DESCRIPTION
The reporter has been using telemetry since the beginning, but it only had it in deps transitively via telemetry_metrics.