### PR TITLE
Improve binary maximum packet size error message

### DIFF
--- a/lib/telemetry_metrics_statsd/packet.ex
+++ b/lib/telemetry_metrics_statsd/packet.ex
@@ -25,7 +25,7 @@ defmodule TelemetryMetricsStatsd.Packet do
 
     if binary_size > max_size do
       # TODO: this should be probably handled in a nicer way
-      raise "Binary size exceeds the provided maximum packet size"
+      raise "Binary size exceeds the provided maximum packet size. You might increase it via the :mtu config."
     end
 
     new_packet_binaries_count = packet_binaries_count + 1


### PR DESCRIPTION
```
[error] Handler {TelemetryMetricsStatsd.EventHandler, #PID<0.838.0>, [:nex, :repo, :query]} has failed and has been detached. Class=:error
Reason=%RuntimeError{message: "Binary size exceeds the provided maximum packet size"}
```

It took me a while to figure this could be increased by [mtu](https://github.com/statsd/statsd/blob/9cf77d87855bcb69a8663135f59aa23825db9797/docs/metric_types.md#multi-metric-packets). I Hope this help at least to figure how to work around the error.