### PR TITLE
Replace NimbleOptions `rename_to` with a custom function

### DIFF
--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -23,7 +23,6 @@ defmodule TelemetryMetricsStatsd.Options do
     ],
     socket_path: [
       type: {:custom, __MODULE__, :socket_path, []},
-      rename_to: :host,
       doc: "Path to the Unix Domain Socket used for publishing instead of the hostname and port."
     ],
     formatter: [
@@ -75,6 +74,7 @@ defmodule TelemetryMetricsStatsd.Options do
   def validate(options) do
     case NimbleOptions.validate(options, @schema) do
       {:ok, options} ->
+        options = rename_socket_path(options)
         {:ok, struct(__MODULE__, options)}
 
       {:error, err} ->
@@ -114,4 +114,14 @@ defmodule TelemetryMetricsStatsd.Options do
 
   def formatter(term),
     do: {:error, "expected :formatter be either :standard or :datadog, got #{inspect(term)}"}
+
+  defp rename_socket_path(opts) do
+    if socket_path = Keyword.get(opts, :socket_path) do
+      opts
+      |> Keyword.put(:host, socket_path)
+      |> Keyword.delete(:socket_path)
+    else
+      opts
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
     [
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:telemetry_metrics, "~> 0.6"},
-      {:nimble_options, "~> 0.3"},
+      {:nimble_options, "~> 0.4"},
       {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:ex_doc, "~> 0.19", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -16,7 +16,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "mock": {:hex, :mock, "0.3.7", "75b3bbf1466d7e486ea2052a73c6e062c6256fb429d6797999ab02fa32f29e03", [:mix], [{:meck, "~> 0.9.2", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm", "4da49a4609e41fd99b7836945c26f373623ea968cfb6282742bcb94440cf7e5c"},
-  "nimble_options": {:hex, :nimble_options, "0.3.5", "a4f6820cdcb4ee444afd78635f323e58e8a5ddf2fbbe9b9d283a99f972034bae", [:mix], [], "hexpm", "f5507cc90033a8d12769522009c80aa9164af6bab245dbd4ad421d008455f1e1"},
+  "nimble_options": {:hex, :nimble_options, "0.4.0", "c89babbab52221a24b8d1ff9e7d838be70f0d871be823165c94dd3418eea728f", [:mix], [], "hexpm", "e6701c1af326a11eea9634a3b1c62b475339ace9456c1a23ec3bc9a847bca02d"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},


### PR DESCRIPTION
Fixes #68 

This PR replaces the nimble_options `:replace_to` with a custom function which achieves the same thing as this option is now deprecated in nimble_options 0.4.

I've also upgraded nimble_options to 0.4.

We had an issue with running the tests locally as it seems the `capture_log`s in some tests aren't capturing long enough to capture the expected error logging. Adding `Process.sleep` fixes those tests but of course that isn't an ideal solution so I've left the tests as is for now.