### PR TITLE
WIP: Larger packets

### DIFF
--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -128,14 +128,14 @@ defmodule TelemetryMetricsStatsd.EventHandler do
   @spec publish_metrics(pid(), :ets.tid(), [binary()]) :: :ok
   defp publish_metrics(reporter, pool_id, packets) do
     case TelemetryMetricsStatsd.get_udp(pool_id) do
-      {:ok, udp} ->
+      {:ok, pid} ->
         Enum.reduce_while(packets, :cont, fn packet, :cont ->
-          case UDP.send(udp, packet) do
+          case UDP.send(pid, packet) do
             :ok ->
               {:cont, :cont}
 
             {:error, reason} ->
-              TelemetryMetricsStatsd.udp_error(reporter, udp, reason)
+              TelemetryMetricsStatsd.udp_error(reporter, pid, reason)
               {:halt, :halt}
           end
         end)

--- a/lib/telemetry_metrics_statsd/pool.ex
+++ b/lib/telemetry_metrics_statsd/pool.ex
@@ -1,0 +1,43 @@
+defmodule TelemetryMetricsStatsd.Pool do
+  @moduledoc false
+
+  @pool __MODULE__
+
+  alias TelemetryMetricsStatsd.UDP
+
+  def new(pool_size, udp_config) do
+    options = [
+      workers: pool_size,
+      worker: {UDP, udp_config}
+    ]
+
+    pool_id =
+      :rand.bytes(10)
+      |> Base.encode16()
+      |> String.to_atom()
+
+    case :wpool.start_sup_pool(pool_id, options) do
+      {:ok, _pid} -> {:ok, pool_id}
+      other -> other
+    end
+  end
+
+  def send(pool_id, packet) do
+    :wpool.cast(pool_id, {:send, packet})
+  end
+
+  def get_udp(pool_id) do
+    :wpool_pool.random_worker(pool_id)
+  end
+
+  def get_workers(pool_id) do
+    :wpool.get_workers(pool_id)
+  end
+
+  def update(pool_id, new_host, new_port) do
+    get_workers(pool_id)
+    |> Enum.each(fn name ->
+      UDP.update(name, new_host, new_port)
+    end)
+  end
+end

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -2,6 +2,7 @@ defmodule TelemetryMetricsStatsd.UDP do
   @moduledoc false
 
   use GenServer
+  require Logger
 
   defstruct [:host, :port, :socket]
 
@@ -20,7 +21,7 @@ defmodule TelemetryMetricsStatsd.UDP do
     GenServer.start_link(__MODULE__, options)
   end
 
-  @spec send(pid, iodata) :: :ok | {:error, term}
+  @spec send(GenServer.name(), iodata) :: :ok | {:error, term}
   def send(pid, data) do
     GenServer.call(pid, {:send, data})
   end
@@ -33,6 +34,9 @@ defmodule TelemetryMetricsStatsd.UDP do
     GenServer.call(pid, :close)
   end
 
+  def stop(pid, reason) do
+    GenServer.stop(pid, reason)
+  end
 
   @impl true
   def init(config) do

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:telemetry_metrics, "~> 0.6"},
       {:nimble_options, "~> 0.4"},
+      {:worker_pool, "~> 6.0"},
       {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:ex_doc, "~> 0.19", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -24,4 +24,5 @@
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+  "worker_pool": {:hex, :worker_pool, "6.0.1", "ca262c2dfb3b4af661b206c82065d86f83922b7227508aa6e0bc34d3e5ae5135", [:rebar3], [], "hexpm", "772e12ccb26909ea7f804b52e86e733df66bb8150f683b591b0a762196494c74"},
 }


### PR DESCRIPTION
Work done so far:

- [X] Change `UDP` from a struct to a GenServer
- [X] Replace custom :ets-based worker pool with [worker_pool](https://github.com/inaka/worker_pool/)
  - Note: I'm not really happy with the solution I landed on for creating multiple concurrent worker pools.

Work remaining:

- [ ] Implement packet buffering, with configurable number of bytes (e.g. for UDP; base it off of MTU minus the statsd-related header. For UDS; 8192 bytes is recommended. See [here](https://docs.datadoghq.com/developers/dogstatsd/high_throughput/#ensure-proper-packet-sizes) for a good guide about tuning for high-throughput metrics)
  - Currently, the tests use a `assert_reported/2` helper function which calls `:gen_udp.recv`. This will likely have to change to accommodate larger packets containing many metrics.
- [ ] Document packet buffering
- [ ] Expose choice of worker selection (I think hash_worker will work well here)
  - In particular, with `hash_worker`, it becomes possible to do client-side aggregation of metrics. For example, if the `foo.bar` counter is incremented once 10,000 times, all those increments go to the same worker, which could emit a single line in an outgoing packet for all 10,000 increments. This type of optimization is less effective with different choices of worker selection.
- [ ] Benchmark metric throughput against [Statix](https://github.com/lexmag/statix)