### PR TITLE
Allow for inet6 option

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -532,20 +532,34 @@ defmodule TelemetryMetricsStatsd do
     %{state | udp_config: %{udp_config | host: new_address}}
   end
 
-  defp configure_host_resolution(%{host: host, port: port}) when is_tuple(host) do
-    %{host: host, port: port}
+  defp configure_host_resolution(%{
+         host: host,
+         port: port,
+         inet_address_family: inet_address_family
+       })
+       when is_tuple(host) do
+    %{host: host, port: port, inet_address_family: inet_address_family}
   end
 
-  defp configure_host_resolution(%{host: host, port: port, host_resolution_interval: interval})
+  defp configure_host_resolution(%{
+         host: host,
+         port: port,
+         inet_address_family: inet_address_family,
+         host_resolution_interval: interval
+       })
        when is_integer(interval) do
-    {:ok, hostent(h_addr_list: [ip | _ips])} = :inet.gethostbyname(host)
+    {:ok, hostent(h_addr_list: [ip | _ips])} = :inet.gethostbyname(host, inet_address_family)
     Process.send_after(self(), :resolve_host, interval)
-    %{host: ip, port: port}
+    %{host: ip, port: port, inet_address_family: inet_address_family}
   end
 
-  defp configure_host_resolution(%{host: host, port: port}) do
-    {:ok, hostent(h_addr_list: [ip | _ips])} = :inet.gethostbyname(host)
-    %{host: ip, port: port}
+  defp configure_host_resolution(%{
+         host: host,
+         port: port,
+         inet_address_family: inet_address_family
+       }) do
+    {:ok, hostent(h_addr_list: [ip | _ips])} = :inet.gethostbyname(host, inet_address_family)
+    %{host: ip, port: port, inet_address_family: inet_address_family}
   end
 
   defp update_pool(pool_id, new_host, new_port) do

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -21,6 +21,11 @@ defmodule TelemetryMetricsStatsd.Options do
       default: 8125,
       doc: "Port of the StatsD server."
     ],
+    inet_address_family: [
+      type: {:in, [:inet, :inet6, :local]},
+      default: :inet,
+      doc: "The inet address family, as specified by the Erlang `:inet.address_family type()`."
+    ],
     socket_path: [
       type: {:custom, __MODULE__, :socket_path, []},
       doc: "Path to the Unix Domain Socket used for publishing instead of the hostname and port."

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -11,22 +11,21 @@ defmodule TelemetryMetricsStatsd.UDP do
 
   @type config :: %{
           :host => :inet.hostname() | :inet.ip_address() | :inet.local_address(),
-          optional(:port) => :inet.port_number()
+          optional(:port) => :inet.port_number(),
+          optional(:inet_address_family) => boolean()
         }
 
   @spec open(config()) ::
           {:ok, t()} | {:error, reason :: term()}
   def open(config) do
-    opts = [active: false]
+    opts = [{:active, false}]
 
     opts =
-      case config.host do
-        {:local, _} ->
-          [:local | opts]
-
-        _ ->
-          opts
-      end
+      Enum.reduce(config, opts, fn
+        {:host, {:local, _}}, opts -> [:local | opts]
+        {:inet_address_family, value}, opts -> [value | opts]
+        {_key, _value}, opts -> opts
+      end)
 
     case :gen_udp.open(0, opts) do
       {:ok, socket} ->


### PR DESCRIPTION
Fixes #78

I'm using this to be able to send metrics over IPv6 on fly.io through WireGuard