### PR TITLE
Fix CI and flaky tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   format:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -32,7 +32,7 @@ jobs:
 
   test:
     name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         otp: ["22.3", "24.0"]
@@ -66,7 +66,7 @@ jobs:
 
   dialyze:
     name: Dialyze on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         otp: ["22.3", "24.0"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
     name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - otp: 22.3
@@ -71,6 +72,7 @@ jobs:
     name: Dialyze on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - otp: 22.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: "24.0"
           elixir-version: "1.12.0"
@@ -29,6 +29,7 @@ jobs:
             deps-
       - run: mix deps.get
       - run: mix format --check-formatted
+
   test:
     name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest
@@ -38,7 +39,7 @@ jobs:
         elixir: ["1.10.4", "1.12.0"]
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
@@ -72,7 +73,7 @@ jobs:
         elixir: ["1.10.4", "1.12.0"]
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,11 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        otp: ["22.3", "24.0"]
-        elixir: ["1.10.4", "1.12.0"]
+        include:
+          - otp: 22.3
+            elixir: 1.10.4
+          - otp: 24.0
+            elixir: 1.12.0
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -69,8 +72,11 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        otp: ["22.3", "24.0"]
-        elixir: ["1.10.4", "1.12.0"]
+        include:
+          - otp: 22.3
+            elixir: 1.10.4
+          - otp: 24.0
+            elixir: 1.12.0
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -328,7 +328,7 @@ defmodule TelemetryMetricsStatsdTest do
 
   describe "UDP error handling" do
     test "reporting a UDP error logs an error" do
-      reporter = start_reporter(metrics: [])
+      reporter = start_reporter(metrics: [], pool_size: 1)
       pool_id = TelemetryMetricsStatsd.get_pool_id(reporter)
       {:ok, udp} = TelemetryMetricsStatsd.get_udp(pool_id)
 
@@ -343,7 +343,7 @@ defmodule TelemetryMetricsStatsdTest do
     end
 
     test "reporting a UDP error for the same socket multiple times generates only one log" do
-      reporter = start_reporter(metrics: [])
+      reporter = start_reporter(metrics: [], pool_size: 1)
       pool_id = TelemetryMetricsStatsd.get_pool_id(reporter)
       {:ok, udp} = TelemetryMetricsStatsd.get_udp(pool_id)
 

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -334,9 +334,11 @@ defmodule TelemetryMetricsStatsdTest do
 
       assert capture_log(fn ->
                TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
-
-               # Wait for processing handle_cast by udp_error.
-               _ = TelemetryMetricsStatsd.get_pool_id(reporter)
+               # errors.
+               eventually(fn ->
+                 {:ok, new_udp} = TelemetryMetricsStatsd.get_udp(pool_id)
+                 new_udp != udp
+               end)
              end) =~ ~r/\[error\] Failed to publish metrics over UDP: :closed/
     end
 
@@ -348,15 +350,19 @@ defmodule TelemetryMetricsStatsdTest do
       assert capture_log(fn ->
                TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
 
-               # Wait for processing handle_cast by udp_error.
-               _ = TelemetryMetricsStatsd.get_pool_id(reporter)
+               eventually(fn ->
+                 {:ok, new_udp} = TelemetryMetricsStatsd.get_udp(pool_id)
+                 new_udp != udp
+               end)
              end) =~ ~r/\[error\] Failed to publish metrics over UDP: :closed/
 
       assert capture_log(fn ->
                TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
 
-               # Wait for processing handle_cast by udp_error.
-               _ = TelemetryMetricsStatsd.get_pool_id(reporter)
+               eventually(fn ->
+                 {:ok, new_udp} = TelemetryMetricsStatsd.get_udp(pool_id)
+                 new_udp != udp
+               end)
              end) == ""
     end
 

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -334,11 +334,9 @@ defmodule TelemetryMetricsStatsdTest do
 
       assert capture_log(fn ->
                TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
-               # errors.
-               eventually(fn ->
-                 {:ok, new_udp} = TelemetryMetricsStatsd.get_udp(pool_id)
-                 new_udp != udp
-               end)
+
+               # Wait for processing handle_cast by udp_error.
+               _ = TelemetryMetricsStatsd.get_pool_id(reporter)
              end) =~ ~r/\[error\] Failed to publish metrics over UDP: :closed/
     end
 
@@ -350,19 +348,15 @@ defmodule TelemetryMetricsStatsdTest do
       assert capture_log(fn ->
                TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
 
-               eventually(fn ->
-                 {:ok, new_udp} = TelemetryMetricsStatsd.get_udp(pool_id)
-                 new_udp != udp
-               end)
+               # Wait for processing handle_cast by udp_error.
+               _ = TelemetryMetricsStatsd.get_pool_id(reporter)
              end) =~ ~r/\[error\] Failed to publish metrics over UDP: :closed/
 
       assert capture_log(fn ->
                TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
 
-               eventually(fn ->
-                 {:ok, new_udp} = TelemetryMetricsStatsd.get_udp(pool_id)
-                 new_udp != udp
-               end)
+               # Wait for processing handle_cast by udp_error.
+               _ = TelemetryMetricsStatsd.get_pool_id(reporter)
              end) == ""
     end
 


### PR DESCRIPTION
## Background

The CI fails on the main branch.

## What I did

- Fix GitHub Actions
  - Use setup-beams
    - https://github.com/actions/setup-elixir is archived.
    - https://github.com/erlef/setup-elixir is redirected to https://github.com/erlef/setup-beam
  - Use ubuntu-20.04 because ubuntu-latest does not have old Erlang/OTP and Elixir versions
    - References:
      - https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt
      - https://repo.hex.pm/builds/otp/ubuntu-22.04/builds.txt
      - https://github.com/beam-telemetry/telemetry_metrics/pull/104
- Fix flaky tests
  - See the comment on the tests.

## How to test

I confirmed that the CI was passed at the forked repository.
See https://github.com/mopp/telemetry_metrics_statsd/pull/2