### PR TITLE
Datadog formatter - Convert tag value of list to multiple tag values with same key

### DIFF
--- a/lib/telemetry_metrics_statsd/formatter/datadog.ex
+++ b/lib/telemetry_metrics_statsd/formatter/datadog.ex
@@ -62,6 +62,14 @@ defmodule TelemetryMetricsStatsd.Formatter.Datadog do
     [:erlang.atom_to_binary(k, :utf8), ?:, "nil"]
   end
 
+  # creates new list with {k, v} of the tail
+  # head through format tag to avoid extra commas
+  # and then combine_tags with the new list
+  defp format_tag(k, [head | tail] = v) when is_list(v) do
+    tags = Enum.map(tail, fn item -> {k, item} end)
+    [format_tag(k, head), combine_tags(tags)]
+  end
+
   defp format_tag(k, v) do
     [:erlang.atom_to_binary(k, :utf8), ?:, to_string(v)]
   end

--- a/test/telemetry_metrics_statsd/formatter/datadog_test.exs
+++ b/test/telemetry_metrics_statsd/formatter/datadog_test.exs
@@ -91,6 +91,34 @@ defmodule TelemetryMetricsStatsd.Formatter.DatadogTest do
     assert format(m, 131.4, []) == "my.awesome.metric:131.4|g"
   end
 
+  test "tag values passed as list are included in the formatted metric as multiple tags" do
+    m = given_last_value("my.awesome.metric", tags: [:method, :item, :status])
+
+    assert format(m, 131, method: "GET", item: ["a", "b", "c"], status: 200) ==
+             "my.awesome.metric:131|g|#method:GET,item:a,item:b,item:c,status:200"
+  end
+
+  test "tag values passed as list with one item are included in the formatted metric" do
+    m = given_last_value("my.awesome.metric", tags: [:method, :item, :status])
+
+    assert format(m, 131, method: "GET", item: ["a"], status: 200) ==
+             "my.awesome.metric:131|g|#method:GET,item:a,status:200"
+  end
+
+  test "tag values passed as list are included in the formatted metric as multiple tags, when missing tag values" do
+    m = given_last_value("my.awesome.metric", tags: [:method, :item, :status])
+
+    assert format(m, 131, item: ["a", "b", "c"], status: 200) ==
+             "my.awesome.metric:131|g|#item:a,item:b,item:c,status:200"
+  end
+
+  test "tag values passed as list with one item are included in the formatted metric, when missing tag values" do
+    m = given_last_value("my.awesome.metric", tags: [:method, :item, :status])
+
+    assert format(m, 131, item: ["a"], status: 200) ==
+             "my.awesome.metric:131|g|#item:a,status:200"
+  end
+
   defp format(metric, value, tags) do
     Datadog.format(metric, value, tags)
     |> :erlang.iolist_to_binary()


### PR DESCRIPTION
To give some context, datadog supports receiving multiple tag values with the same key, so you could have a dogstatsd datagram such as:

```
application_name.metric_name.event.amount:1|c|#type:failed,reason:reason1,reason:reason2
```

There's some work that I'm involved with on migrating an elixir application from https://hexdocs.pm/statix/Statix.html to use the telemetry module and this library for recording telemetry, and sending them to datadog. statix supported a list of tags, which could be ["tag1:value", "tag1:secondvalue", "tag2"].

With the telemetry module and telemetry_metrics_statsd, we can send a telemetry metric with metadata such as:

```
%{type: failed, reason: [reason1, reason2]}
```

The reason list is being converted to a string by the datadog formatter, and then the datagram looks like:

```
application_name.metric_name.event.amount:1|c|#type:failed,reason:reason1reason2
```

The main downside of that is that in datadog dashboards, the reason field is one string, so it's not as clean looking. When you have multiple tag values, you can do queries on reason:reason1, compared to now doing a string search of reason:*reason1*.  As well, when displaying a table of the tag, it will show up as reason1, reason2 automatically if there's multiple tag values.

The changes in this pull request detect a list and then take each item in the list as a new tag value so the datagram looks like the first example of

```
application_name.metric_name.event.amount:1|c|#type:failed,reason:reason1,reason:reason2
```

If these changes shouldn't be the default, it could also be put behind a config parameter when setting up TelemetryMetricsStatsd