### PR TITLE
issue #91 chore: bump telemetry_metrics from 0.6 -> 1.0. no breaking change

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
   defp deps do
     [
       {:telemetry, "~> 0.4 or ~> 1.0"},
-      {:telemetry_metrics, "~> 0.6"},
+      {:telemetry_metrics, "~> 1.0"},
       {:nimble_options, "~> 0.4 or ~> 1.0"},
       {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 1.3", only: :test, runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
   defp deps do
     [
       {:telemetry, "~> 0.4 or ~> 1.0"},
-      {:telemetry_metrics, "~> 1.0"},
+      {:telemetry_metrics, "~> 0.6 or ~> 1.0"},
       {:nimble_options, "~> 0.4 or ~> 1.0"},
       {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 1.3", only: :test, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,6 @@
   "nimble_options": {:hex, :nimble_options, "1.0.1", "b448018287b22584e91b5fd9c6c0ad717cb4bcdaa457957c8d57770f56625c43", [:mix], [], "hexpm", "078b2927cd9f84555be6386d56e849b0c555025ecccf7afee00ab6a9e6f63837"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
-  "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
-  "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
+  "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
+  "telemetry_metrics": {:hex, :telemetry_metrics, "1.0.0", "29f5f84991ca98b8eb02fc208b2e6de7c95f8bb2294ef244a176675adc7775df", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "f23713b3847286a534e005126d4c959ebcca68ae9582118ce436b521d1d47d5d"},
 }


### PR DESCRIPTION
`telemetry_metrics` lib has released v1.0 ([ref](https://github.com/beam-telemetry/telemetry_metrics/blob/main/CHANGELOG.md#100)) and there is no change in API.

however, `telemetry_metrics_statsd` still depends on v0.6. just bump the mix file.

this PR should also close issue 91 https://github.com/beam-telemetry/telemetry_metrics_statsd/issues/91