### PR TITLE
Update binary size exceeds message 

### DIFF
--- a/lib/telemetry_metrics_statsd/packet.ex
+++ b/lib/telemetry_metrics_statsd/packet.ex
@@ -25,7 +25,7 @@ defmodule TelemetryMetricsStatsd.Packet do
 
     if binary_size > max_size do
       # TODO: this should be probably handled in a nicer way
-      raise "Binary size exceeds the provided maximum packet size. You might increase it via the :mtu config."
+      raise "Binary size #{binary_size} exceeds the provided maximum packet size #{max_size}. You might increase it via the :mtu config."
     end
 
     new_packet_binaries_count = packet_binaries_count + 1

--- a/lib/telemetry_metrics_statsd/packet.ex
+++ b/lib/telemetry_metrics_statsd/packet.ex
@@ -25,7 +25,7 @@ defmodule TelemetryMetricsStatsd.Packet do
 
     if binary_size > max_size do
       # TODO: this should be probably handled in a nicer way
-      raise "Binary size #{binary_size} exceeds the provided maximum packet size #{max_size}. You might increase it via the :mtu config."
+      raise "Binary size #{binary_size} bytes exceeds the provided maximum packet size #{max_size} bytes. You might increase it via the :mtu config."
     end
 
     new_packet_binaries_count = packet_binaries_count + 1


### PR DESCRIPTION
Update binary size exceeds message to include size values and avoid guessing max mtu size needed