### PR TITLE
Fix incorrect state when hostname resolution fails

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -511,6 +511,8 @@ defmodule TelemetryMetricsStatsd do
             "Failed to resolve the hostname #{host}: #{inspect(reason)}. " <>
               "Using the previously resolved address of #{:inet.ntoa(current_address)}."
           )
+
+          state
       end
 
     Process.send_after(self(), :resolve_host, interval)


### PR DESCRIPTION
This PR is much less ambitious than #94 (and so I expect it would be an easier merge). In this case, we just fix the issue when the process is already started, but an error in the resolution of the hostname leads to an incorrect internal state.

Without this patch, the `new_state` will be `:ok`, as that is the return from the logger function.
Afterwards, when going to the `terminate` callback, then we try to call `EventHandler.detach(state.handler_ids)`, which translates to `EventHandler.detach(:ok.handler_ids)` and fails.