### PR TITLE
Add support for Datadog Service Checks

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -146,6 +146,23 @@ defmodule TelemetryMetricsStatsd do
 
       "vm.memory.total:1024|g"
 
+  When the `report_as: :service_check` reporter option is passed in conjunction with the `datadog`
+  reporter, the last value metric is reported as a service check. Datadog only supports the following
+  values: 0 - OK, 1 - Warn, 2 - Critical, 3 - Unknown. Additionally the "host" and "message"
+  properties are not supported, as telemetry_metrics doesn't have a way to express them.
+
+  Given the metric definition
+
+      last_value("my_service.fragile_cache.status", reporter_options: [report_as: :service_check])
+
+  and the event
+
+      :telemetry.execute([:my_service, :fragile_cache], %{status: 1})
+
+  the following would be sent to StatsD
+
+      "_sc|my_service.fragile_cache.status|1"
+
   #### Sum
 
   Sum metric is also represented as a gauge - the difference is that it always changes relatively

--- a/test/telemetry_metrics_statsd/formatter/datadog_test.exs
+++ b/test/telemetry_metrics_statsd/formatter/datadog_test.exs
@@ -91,6 +91,18 @@ defmodule TelemetryMetricsStatsd.Formatter.DatadogTest do
     assert format(m, 131.4, []) == "my.awesome.metric:131.4|g"
   end
 
+  test "report_as: service_check for last_value" do
+    m = given_last_value("my.awesome.metric", reporter_options: [report_as: :service_check])
+
+    assert format(m, 0, []) == "_sc|my.awesome.metric|0"
+  end
+
+  test "report_as: service_check for last_value with tags" do
+    m = given_last_value("my.awesome.metric", reporter_options: [report_as: :service_check])
+
+    assert format(m, 0, [host: "foo", app: "bar"]) == "_sc|my.awesome.metric|0|#host:foo,app:bar"
+  end
+
   defp format(metric, value, tags) do
     Datadog.format(metric, value, tags)
     |> :erlang.iolist_to_binary()


### PR DESCRIPTION
These are implemented as `last_value` metrics with `report_as: :service_check`. It does not support the "host" or "message" property, since TelemetryMetrics doesn't really seem to have a good way to express them.

Fixes #72