### PR TITLE
Async emit

### DIFF
--- a/lib/telemetry_metrics_statsd/emitter.ex
+++ b/lib/telemetry_metrics_statsd/emitter.ex
@@ -1,5 +1,6 @@
 defmodule TelemetryMetricsStatsd.Emitter do
   @moduledoc false
   @callback emit(name :: GenServer.name(), metric :: iodata()) :: :ok
-  @callback emit_internal(name :: GenServer.name(), metric :: iodata()) :: :ok
+  @callback emit_async(name :: GenServer.name(), metric :: iodata()) :: :ok
+  @callback emit_internal(name :: GenServer.name(), metric :: iodata) :: :ok
 end

--- a/lib/telemetry_metrics_statsd/emitter/domain.ex
+++ b/lib/telemetry_metrics_statsd/emitter/domain.ex
@@ -22,6 +22,11 @@ defmodule TelemetryMetricsStatsd.Emitter.Domain do
   end
 
   @impl true
+  def emit_async(name, metric) do
+    GenServer.cast(via_tuple(name), {:emit, metric})
+  end
+
+  @impl true
   def emit_internal(name, metric) do
     GenServer.call(via_tuple(name), {:emit_internal, metric})
   end
@@ -90,6 +95,14 @@ defmodule TelemetryMetricsStatsd.Emitter.Domain do
   end
 
   @impl true
+  def handle_cast({:emit, metric}, %__MODULE__{} = state) do
+    case write_to_socket(state, metric, :normal) do
+      {:ok, state} -> {:noreply, state}
+      {:error, reason} -> {:stop, reason, state}
+    end
+  end
+
+  @impl true
   def handle_info(:check_dwell_time, %__MODULE__{} = state) do
     send(self(), {:probe_dwell_time, dwell_timestamp()})
     {:noreply, state}
@@ -112,6 +125,7 @@ defmodule TelemetryMetricsStatsd.Emitter.Domain do
   end
 
   # Private
+
   defp write_to_socket(%__MODULE__{} = state, data, :internal) do
     :socket.send(state.socket, data)
   end

--- a/lib/telemetry_metrics_statsd/emitter/udp.ex
+++ b/lib/telemetry_metrics_statsd/emitter/udp.ex
@@ -42,6 +42,11 @@ defmodule TelemetryMetricsStatsd.Emitter.UDP do
   end
 
   @impl TelemetryMetricsStatsd.Emitter
+  def emit_async(name, data) do
+    GenServer.cast(via_tuple(name), {:emit, data})
+  end
+
+  @impl TelemetryMetricsStatsd.Emitter
   def emit_internal(name, data) do
     GenServer.cast(via_tuple(name), {:emit_internal, data})
   end
@@ -81,15 +86,7 @@ defmodule TelemetryMetricsStatsd.Emitter.UDP do
   @behaviour TelemetryMetricsStatsd.Emitter
   @impl GenServer
   def handle_call({:emit, data}, _from, %__MODULE__{} = state) do
-    new_state =
-      case add_to_buffer(state, data) do
-        {:flush, buffers, new_buffer} when is_list(buffers) ->
-          Enum.each(buffers, &write_to_socket!(state, &1))
-          %__MODULE__{state | buffer: new_buffer}
-
-        {:buffer, buffer} ->
-          %__MODULE__{state | buffer: buffer}
-      end
+    new_state = do_emit(state, data)
 
     {:reply, :ok, new_state, state.flush_timeout}
   end
@@ -99,6 +96,12 @@ defmodule TelemetryMetricsStatsd.Emitter.UDP do
     write_to_socket!(state, new_buffer(data))
 
     {:noreply, state, adjust_flush_timeout(state)}
+  end
+
+  @impl true
+  def handle_cast({:emit, data}, %__MODULE__{} = state) do
+    new_state = do_emit(state, data)
+    {:noreply, new_state, state.flush_timeout}
   end
 
   @impl true
@@ -163,6 +166,17 @@ defmodule TelemetryMetricsStatsd.Emitter.UDP do
   end
 
   ## Private
+
+  defp do_emit(%__MODULE__{} = state, data) do
+    case add_to_buffer(state, data) do
+      {:flush, buffers, new_buffer} when is_list(buffers) ->
+        Enum.each(buffers, &write_to_socket!(state, &1))
+        %__MODULE__{state | buffer: new_buffer}
+
+      {:buffer, buffer} ->
+        %__MODULE__{state | buffer: buffer}
+    end
+  end
 
   defp open_socket(%__MODULE__{} = state) do
     with {:ok, socket} <- :socket.open(state.inet_address_family, :dgram, :udp),

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -3,6 +3,19 @@ defmodule TelemetryMetricsStatsd.EventHandler do
 
   alias Telemetry.Metrics
   alias TelemetryMetricsStatsd.Formatter
+  alias TelemetryMetricsStatsd.Options
+
+  @type function_name :: atom()
+
+  defstruct [
+    :emitter_function,
+    :emitter_module,
+    :formatter,
+    :global_tags,
+    :metrics,
+    :name,
+    :prefix
+  ]
 
   alias TelemetryMetricsStatsd.Options
   use GenServer
@@ -14,30 +27,29 @@ defmodule TelemetryMetricsStatsd.EventHandler do
   end
 
   @spec attach(
-          GenServer.name(),
-          [Metrics.t()],
+          options :: Options.t(),
           emitter_module :: module(),
-          prefix :: String.t() | nil,
-          formatter :: Formatter.t(),
-          global_tags :: Keyword.t()
-        ) :: [
-          :telemetry.handler_id()
-        ]
-  def attach(registered_name, metrics, emitter_module, prefix, formatter, global_tags) do
-    metrics_by_event = Enum.group_by(metrics, & &1.event_name)
+          emitter_function :: function_name()
+        ) ::
+          [:telemetry.handler_id()]
+  def attach(%Options{} = options, emitter_module, emitter_function) do
+    metrics_by_event = Enum.group_by(options.metrics, & &1.event_name)
+    registered_name = options.name
 
     for {event_name, metrics} <- metrics_by_event do
       handler_id = handler_id(registered_name, event_name, emitter_module)
 
-      :ok =
-        :telemetry.attach(handler_id, event_name, &__MODULE__.handle_event/4, %{
-          emitter_module: emitter_module,
-          formatter: formatter,
-          global_tags: global_tags,
-          metrics: metrics,
-          name: registered_name,
-          prefix: prefix
-        })
+      state = %__MODULE__{
+        emitter_function: emitter_function,
+        emitter_module: emitter_module,
+        formatter: options.formatter,
+        global_tags: options.global_tags,
+        metrics: metrics,
+        name: registered_name,
+        prefix: options.prefix
+      }
+
+      :ok = :telemetry.attach(handler_id, event_name, &__MODULE__.handle_event/4, state)
 
       handler_id
     end
@@ -48,14 +60,17 @@ defmodule TelemetryMetricsStatsd.EventHandler do
     Enum.each(handler_ids, &:telemetry.detach/1)
   end
 
-  def handle_event(event, measurements, metadata, %{
-        emitter_module: emitter_module,
-        formatter: formatter_mod,
-        global_tags: global_tags,
-        metrics: metrics,
-        name: name,
-        prefix: prefix
-      }) do
+  def handle_event(event, measurements, metadata, %__MODULE__{} = state) do
+    %__MODULE__{
+      emitter_function: emitter_function,
+      emitter_module: emitter_module,
+      formatter: formatter_mod,
+      global_tags: global_tags,
+      metrics: metrics,
+      name: name,
+      prefix: prefix
+    } = state
+
     metrics =
       for metric <- metrics,
           keep?(metric, metadata),
@@ -74,7 +89,7 @@ defmodule TelemetryMetricsStatsd.EventHandler do
     if internal?(event) do
       publish_internal_metrics(emitter_module, name, metrics)
     else
-      publish_metrics(emitter_module, name, metrics)
+      publish_metrics(emitter_module, emitter_function, name, metrics)
     end
   end
 
@@ -83,21 +98,23 @@ defmodule TelemetryMetricsStatsd.EventHandler do
   def init([%Options{} = options, emitter_module]) do
     Process.flag(:trap_exit, true)
 
-    handler_ids =
-      attach(
-        options.name,
-        options.metrics,
-        emitter_module,
-        options.prefix,
-        options.formatter,
-        options.global_tags
-      )
+    emitter_function =
+      case Options.emit_kind(options) do
+        :sync ->
+          :emit
+
+        :async ->
+          :emit_async
+      end
+
+    handler_ids = attach(options, emitter_module, emitter_function)
 
     {:ok, handler_ids}
   end
 
   @impl true
   def handle_info({:EXIT, _pid, reason}, handler_ids) do
+    detach(handler_ids)
     {:stop, reason, handler_ids}
   end
 
@@ -160,11 +177,16 @@ defmodule TelemetryMetricsStatsd.EventHandler do
   defp internal?([:telemetry_metrics_statsd | _]), do: true
   defp internal?(_), do: false
 
-  @spec publish_metrics(emitter_module :: module(), name :: GenServer.name(), [binary()]) :: :ok
-  defp publish_metrics(_emitter_module, _name, []), do: :ok
+  @spec publish_metrics(
+          emitter_module :: module(),
+          emitter_function :: atom(),
+          name :: GenServer.name(),
+          [binary()]
+        ) :: :ok
+  defp publish_metrics(_emitter_module, _emitter_function, _name, []), do: :ok
 
-  defp publish_metrics(emitter_module, name, metrics) do
-    Enum.each(metrics, fn metric -> emitter_module.emit(name, metric) end)
+  defp publish_metrics(emitter_module, emitter_function, name, metrics) do
+    Enum.each(metrics, fn metric -> apply(emitter_module, emitter_function, [name, metric]) end)
   end
 
   defp publish_internal_metrics(_emitter_module, _name, []), do: :ok

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -75,7 +75,7 @@ defmodule TelemetryMetricsStatsd.Options do
         "The number of metrics emitters in the pool. Each metric emitter contains either a UDP or Unix Domain Socket."
     ],
     max_queue_dwell_time: [
-      type: :pos_integer,
+      type: {:or, [nil, :pos_integer]},
       default: 1000,
       doc:
         "The maximum amount of time, in milliseconds, a message should wait in the emitter's message queue before messages are throttled. " <>

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -82,8 +82,8 @@ defmodule TelemetryMetricsStatsd.Options do
           "If a probe message waits in the queue longer than `max_queue_dwell_time`, the percentage of " <>
           "messages emitted is reduced by 50%. The percentage of messages emitted goes up by 1% if a probe message sits in " <>
           "the queue less than the `max_queue_dwell_time`. " <>
-          "This setting enables asynchronous metrics emission, without any backpressure on the caller, since throttling will provide " <>
-          "overload protection. Asynchronous metric emission should have less impact on callers than the default synchronous emission. "
+          "When this option is not `nil`, metrics are emitted asynchronously, which should have less impact on the callers than the synchronous emission. " <>
+          "You can switch to synchronous emission by setting this option to `nil`."
     ],
     dwell_time_check_interval: [
       type: :pos_integer,

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -79,8 +79,10 @@ defmodule TelemetryMetricsStatsd.Options do
       doc:
         "The maximum amount of time, in milliseconds, a message should wait in the emitter's message queue before messages are throttled. " <>
           "If a probe message waits in the queue longer than `max_queue_dwell_time`, the percentage of " <>
-          "messages emitted is reduced by 50%. The percentage of messages emitted goes up by 1% if a probe message sits in" <>
-          "the queue less than the `max_queue_dwell_time`."
+          "messages emitted is reduced by 50%. The percentage of messages emitted goes up by 1% if a probe message sits in " <>
+          "the queue less than the `max_queue_dwell_time`. " <>
+          "This setting enables asynchronous metrics emission, without any backpressure on the caller, since throttling will provide " <>
+          "overload protection. Asynchronous metric emission should have less impact on callers than the default synchronous emission. "
     ],
     dwell_time_check_interval: [
       type: :pos_integer,
@@ -97,6 +99,8 @@ defmodule TelemetryMetricsStatsd.Options do
   ]
 
   defstruct Keyword.keys(@schema)
+
+  @type t :: %__MODULE__{}
 
   @spec docs() :: String.t()
   def docs do
@@ -147,6 +151,15 @@ defmodule TelemetryMetricsStatsd.Options do
 
   def formatter(term),
     do: {:error, "expected :formatter be either :standard or :datadog, got #{inspect(term)}"}
+
+  @spec emit_kind(t()) :: :sync | :async
+  def emit_kind(%__MODULE__{} = options) do
+    if is_integer(options.max_queue_dwell_time) do
+      :async
+    else
+      :sync
+    end
+  end
 
   defp rename_socket_path(opts) do
     if socket_path = Keyword.get(opts, :socket_path) do

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -76,6 +76,7 @@ defmodule TelemetryMetricsStatsd.Options do
     ],
     max_queue_dwell_time: [
       type: :pos_integer,
+      default: 1000,
       doc:
         "The maximum amount of time, in milliseconds, a message should wait in the emitter's message queue before messages are throttled. " <>
           "If a probe message waits in the queue longer than `max_queue_dwell_time`, the percentage of " <>

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -656,6 +656,38 @@ defmodule TelemetryMetricsStatsdTest do
     end
   end
 
+  describe "async emit" do
+    test "is disabled by default" do
+      spy(Emitter.UDP)
+      {socket, port} = given_udp_port_opened()
+
+      counter = given_counter("async_emit.count")
+
+      start_reporter(metrics: [counter], port: port)
+
+      :telemetry.execute([:async_emit], %{}, %{})
+
+      assert_reported(socket, "async_emit.count:1|c")
+      refute_called(Emitter.UDP.emit_async(_name, _data))
+    end
+
+    test "is enabled if the max_queue_dwell_time is set" do
+      spy(Emitter.UDP)
+      {socket, port} = given_udp_port_opened()
+
+      counter = given_counter("async_emit.count")
+
+      start_reporter(metrics: [counter], port: port, max_queue_dwell_time: 50)
+
+      expected_metric = "async_emit.count:1|c"
+      :telemetry.execute([:async_emit], %{}, %{})
+
+      assert_reported(socket, expected_metric)
+      assert_called(Emitter.UDP.emit_async(_name, data))
+      assert data == expected_metric
+    end
+  end
+
   defp given_udp_port_opened(inet_address_family \\ :inet) do
     {:ok, socket} = :gen_udp.open(0, [:binary, inet_address_family, active: false])
 

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -657,7 +657,7 @@ defmodule TelemetryMetricsStatsdTest do
   end
 
   describe "async emit" do
-    test "is disabled by default" do
+    test "is enabled by default" do
       spy(Emitter.UDP)
       {socket, port} = given_udp_port_opened()
 
@@ -668,7 +668,7 @@ defmodule TelemetryMetricsStatsdTest do
       :telemetry.execute([:async_emit], %{}, %{})
 
       assert_reported(socket, "async_emit.count:1|c")
-      refute_called(Emitter.UDP.emit_async(_name, _data))
+      assert_called(Emitter.UDP.emit_async(_name, _data))
     end
 
     test "is enabled if the max_queue_dwell_time is set" do
@@ -684,6 +684,23 @@ defmodule TelemetryMetricsStatsdTest do
 
       assert_reported(socket, expected_metric)
       assert_called(Emitter.UDP.emit_async(_name, data))
+      assert data == expected_metric
+    end
+
+    test "is disbled if the max_queue_dwell_time is set to nil" do
+      spy(Emitter.UDP)
+      {socket, port} = given_udp_port_opened()
+
+      counter = given_counter("async_emit.count")
+
+      start_reporter(metrics: [counter], port: port, max_queue_dwell_time: nil)
+
+      expected_metric = "async_emit.count:1|c"
+      :telemetry.execute([:async_emit], %{}, %{})
+
+      assert_reported(socket, expected_metric)
+      refute_called(Emitter.UDP.emit_async(_name, data))
+      assert_called(Emitter.UDP.emit(_name, data))
       assert data == expected_metric
     end
   end


### PR DESCRIPTION
During load testing at whatnot, we discovered that emitting metrics under load incurred latency. This was intentional, the genserver for emitters was creating backparessure. However, we also enabled the max dwell time feature, which would provide enough safety on its own.

This pr allows metrics to be emitted asynchronously when the library is configured to use a max dwell time.